### PR TITLE
Changes to better house-keep the operator (MULTI-90, MULTI-91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ operator-sdk up local --namespace=kubefed-test
 
 This will run the operator configured to watch the `kubefed-test` namespace.
 
-After that step, you can create a `KubeFed` in the `kubefed-test` namespace to drive the installation in that namespace:
+After that step, you can create a `KubeFed` custom resource in the `kubefed-test` namespace to drive the installation in that namespace:
 
 ```
 $ kubectl create -f deploy/crds/operator_v1alpha1_kubefed_cr.yaml -n kubefed-test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # kubefed-operator
 
-Prototype operator for [KubeFed](https://github.com/kubernetes-sigs/federation-v2). Planned to eventually replace the [federation-v2-operator repo](https://github.com/openshift/federation-v2-operator).
-
-Note, currently, this operator only supports deploying KubeFed in a namespace-scoped fashion.
+This repository contains code for an operator for deploying [KubeFed](https://github.com/kubernetes-sigs/federation-v2). It is planned to eventually replace the [federation-v2-operator repo](https://github.com/openshift/federation-v2-operator).
 
 ## Deploying and testing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kubefed-operator
 
-This repository contains code for an operator for deploying [KubeFed](https://github.com/kubernetes-sigs/federation-v2). It is planned to replace the [federation-v2-operator repo](https://github.com/openshift/federation-v2-operator).
+This repository contains code for an operator for deploying [KubeFed](https://github.com/kubernetes-sigs/kubefed). It is planned to replace the [federation-v2-operator repo](https://github.com/openshift/federation-v2-operator).
 
 ## Deploying and testing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kubefed-operator
 
-This repository contains code for an operator for deploying [KubeFed](https://github.com/kubernetes-sigs/federation-v2). It is planned to eventually replace the [federation-v2-operator repo](https://github.com/openshift/federation-v2-operator).
+This repository contains code for an operator for deploying [KubeFed](https://github.com/kubernetes-sigs/federation-v2). It is planned to replace the [federation-v2-operator repo](https://github.com/openshift/federation-v2-operator).
 
 ## Deploying and testing
 

--- a/pkg/controller/kubefed/kubefed_controller.go
+++ b/pkg/controller/kubefed/kubefed_controller.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"strings"
 
+	"github.com/operator-framework/operator-sdk/pkg/predicate"
+
 	mf "github.com/jcrossley3/manifestival"
 	kubefedv1alpha1 "github.com/openshift/kubefed-operator/pkg/apis/operator/v1alpha1"
 	"github.com/openshift/kubefed-operator/version"
@@ -54,7 +56,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource KubeFed
-	err = c.Watch(&source.Kind{Type: &kubefedv1alpha1.KubeFed{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &kubefedv1alpha1.KubeFed{}}, &handler.EnqueueRequestForObject{}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ensure that the operator only watches it's own namespace.
When the version is updated on the status of the install resource (kubefed-resource), make sure that the reconcile loop doesn't run again.