### PR TITLE
Fix the operator for rc2 deployment.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,6 +39,11 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
 	log.Info(fmt.Sprintf("Operator Version: %v", operatorVersion.Version))
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Error(err, "Got an error when getting the working directory")
+	}
+	log.Info(fmt.Sprintf("Starting dir: %v", dir))
 }
 
 func main() {

--- a/deploy/resources/deployment.yaml
+++ b/deploy/resources/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - -v=5
         - --logtostderr
         command:
-        - /hyperfed/controller-manager
+        - /root/controller-manager
         image: quay.io/kubernetes-multicluster/kubefed:v0.1.0-rc2
         imagePullPolicy: Always
         name: controller-manager

--- a/kubefed-operator-ci.Dockerfile
+++ b/kubefed-operator-ci.Dockerfile
@@ -15,7 +15,6 @@ ENV BIN_DIR="build/_output/bin" \
 WORKDIR /go/src/github.com/openshift/kubefed-operator
 
 RUN mkdir -p ${BIN_DIR} \
-    && ls -alt * \
     && echo "Building "${PROJECT_NAME}"..." \
     && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=off go build -o ${BIN_DIR}/${PROJECT_NAME} -i ${BUILD_PATH}
 


### PR DESCRIPTION
Print the working directory of the daemon
Remove the ls directive in the builder's RUN
Update the deployment yaml to conform to rc2 kubefed path (/root/controller-manager)