### PR TITLE
Fix wrong filename reference on art.yaml

### DIFF
--- a/deploy/olm-catalog/kubefed-operator/art.yaml
+++ b/deploy/olm-catalog/kubefed-operator/art.yaml
@@ -7,7 +7,7 @@ updates:
     # replace entire version line, otherwise would replace 4.2.0 anywhere
     - search: "version: 4.2.0"
       replace: "version: {FULL_VER}"
-  - file: "kubefed-operator-package.yaml"
+  - file: "kubefed-operator.package.yaml"
     update_list:
     - search: "currentCSV: kubefed-operator.v{MAJOR}.{MINOR}.0"
       replace: "currentCSV: kubefed-operator.{FULL_VER}"


### PR DESCRIPTION
Otherwise the build explodes with the following msg:
```
kubefed-operator-package.yaml does not exist as defined in art.yaml
```