### PR TITLE
Update CRDs from rc-5 to rc-6

### DIFF
--- a/deploy/crds/core_v1beta1_federatedtypeconfig_crd.yaml
+++ b/deploy/crds/core_v1beta1_federatedtypeconfig_crd.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: FederatedTypeConfig
     plural: federatedtypeconfigs
+    shortNames:
+    - ftc
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/olm-catalog/kubefed-operator/0.1.0/core_v1beta1_federatedtypeconfig_crd.yaml
+++ b/deploy/olm-catalog/kubefed-operator/0.1.0/core_v1beta1_federatedtypeconfig_crd.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: FederatedTypeConfig
     plural: federatedtypeconfigs
+    shortNames:
+    - ftc
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/olm-catalog/kubefed-operator/0.1.0/kubefed-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubefed-operator/0.1.0/kubefed-operator.v0.1.0.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Integration & Delivery
     certified: "false"
-    containerImage: quay.io/openshift/kubefed-operator:v0.1.0-rc5
+    containerImage: quay.io/openshift/kubefed-operator:v0.1.0-rc6
     createdAt: "2019-06-14T00:00:00Z"
     description: Gain Hybrid Cloud capabilities between your clusters with Kubernetes
       Federation.
@@ -399,8 +399,8 @@ spec:
     [GitHub](https://github.com/kubernetes-sigs/kubefed/releases).
 
     ```
-     $ curl -Ls https://github.com/kubernetes-sigs/kubefed/releases/download/v0.1.0-rc5/kubefedctl-0.1.0-rc5-linux-amd64.tgz
-     $ tar -xvzf kubefedctl-0.1.0-rc5-linux-amd64.tgz
+     $ curl -Ls https://github.com/kubernetes-sigs/kubefed/releases/download/v0.1.0-rc6/kubefedctl-0.1.0-rc6-linux-amd64.tgz
+     $ tar -xvzf kubefedctl-0.1.0-rc6-linux-amd64.tgz
      $ chmod u+x kubefedctl
      $ sudo mv kubefedctl /usr/local/bin/ # make sure the location is in the PATH
     ```
@@ -679,7 +679,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kubefed-operator
-                image: quay.io/openshift/kubefed-operator:v0.1.0-rc5
+                image: quay.io/openshift/kubefed-operator:v0.1.0-rc6
                 imagePullPolicy: Always
                 name: kubefed-operator
                 resources: {}

--- a/deploy/olm-catalog/kubefed-operator/4.2/core_v1beta1_federatedtypeconfig_crd.yaml
+++ b/deploy/olm-catalog/kubefed-operator/4.2/core_v1beta1_federatedtypeconfig_crd.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: FederatedTypeConfig
     plural: federatedtypeconfigs
+    shortNames:
+    - ftc
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/olm-catalog/kubefed-operator/4.2/kubefed-operator.v4.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubefed-operator/4.2/kubefed-operator.v4.2.0.clusterserviceversion.yaml
@@ -210,7 +210,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Integration & Delivery
     certified: "false"
-    containerImage: quay.io/openshift/kubefed-operator:v0.1.0-rc5
+    containerImage: quay.io/openshift/kubefed-operator:v0.1.0-rc6
     createdAt: "2019-06-14T00:00:00Z"
     description: Gain Hybrid Cloud capabilities between your clusters with Kubernetes
       Federation.
@@ -401,8 +401,8 @@ spec:
     [GitHub](https://github.com/kubernetes-sigs/kubefed/releases).
 
     ```
-     $ curl -Ls https://github.com/kubernetes-sigs/kubefed/releases/download/v0.1.0-rc5/kubefedctl-0.1.0-rc5-linux-amd64.tgz
-     $ tar -xvzf kubefedctl-0.1.0-rc5-linux-amd64.tgz
+     $ curl -Ls https://github.com/kubernetes-sigs/kubefed/releases/download/v0.1.0-rc6/kubefedctl-0.1.0-rc6-linux-amd64.tgz
+     $ tar -xvzf kubefedctl-0.1.0-rc6-linux-amd64.tgz
      $ chmod u+x kubefedctl
      $ sudo mv kubefedctl /usr/local/bin/ # make sure the location is in the PATH
     ```
@@ -683,7 +683,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kubefed-operator
-                image: quay.io/openshift/kubefed-operator:v0.1.0-rc5
+                image: quay.io/openshift/kubefed-operator:v0.1.0-rc6
                 imagePullPolicy: Always
                 name: kubefed-operator
                 resources: {}


### PR DESCRIPTION
Not mergeable until we create an image for an `rc-6` release (quay.io/openshift/kubefed-operator:v0.1.0-rc6)