### PR TITLE
Updates for CRD and operator yamls

### DIFF
--- a/deploy/crds/operator_v1alpha1_kubefedwebhook_crd.yaml
+++ b/deploy/crds/operator_v1alpha1_kubefedwebhook_crd.yaml
@@ -32,6 +32,10 @@ spec:
           - type: "nullable"
           - type: object
         status:
+          properties:
+            version:
+              description: The version of the installed release
+              type: string
           type: object
   version: v1alpha1
   versions:

--- a/deploy/olm-catalog/kubefed-operator/0.1.0/operator_v1alpha1_kubefedwebhook_crd.yaml
+++ b/deploy/olm-catalog/kubefed-operator/0.1.0/operator_v1alpha1_kubefedwebhook_crd.yaml
@@ -32,6 +32,10 @@ spec:
           - type: "nullable"
           - type: object
         status:
+          properties:
+            version:
+              description: The version of the installed release
+              type: string
           type: object
   version: v1alpha1
   versions:

--- a/deploy/olm-catalog/kubefed-operator/4.2/operator_v1alpha1_kubefedwebhook_crd.yaml
+++ b/deploy/olm-catalog/kubefed-operator/4.2/operator_v1alpha1_kubefedwebhook_crd.yaml
@@ -32,6 +32,10 @@ spec:
           - type: "nullable"
           - type: object
         status:
+          properties:
+            version:
+              description: The version of the installed release
+              type: string
           type: object
   version: v1alpha1
   versions:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: kubefed-operator
           # Replace this with the built image name
-          image: quay.io/openshift/kubefed-operator:v0.1.0-rc5
+          image: quay.io/openshift/kubefed-operator:v0.1.0-rc6
           command:
           - kubefed-operator
           imagePullPolicy: Always


### PR DESCRIPTION
This PR updates the image ref for operator yaml to rc6.
It also updates webhook CRD to have a version property for the status.
This is needed for the scorecard tests to pass.