### PR TITLE
Reparse the resources directory after a successful reconcile

### DIFF
--- a/deploy/olm-catalog/kubefed-operator/0.1.0/kubefed-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubefed-operator/0.1.0/kubefed-operator.v0.1.0.clusterserviceversion.yaml
@@ -358,6 +358,7 @@ spec:
           - list
           - create
           - update
+          - delete
         - apiGroups:
           - types.kubefed.io
           resources:

--- a/deploy/olm-catalog/kubefed-operator/4.2/kubefed-operator.v4.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubefed-operator/4.2/kubefed-operator.v4.2.0.clusterserviceversion.yaml
@@ -358,6 +358,7 @@ spec:
           - list
           - create
           - update
+          - delete
         - apiGroups:
           - types.kubefed.io
           resources:

--- a/deploy/resources/controller/role.yaml
+++ b/deploy/resources/controller/role.yaml
@@ -36,6 +36,7 @@ rules:
   - list
   - create
   - update
+  - delete
 - apiGroups:
   - types.kubefed.io
   resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -159,6 +159,7 @@ rules:
   - list
   - create
   - update
+  - delete
 - apiGroups:
   - types.kubefed.io
   resources:

--- a/pkg/controller/kubefed/kubefed_controller.go
+++ b/pkg/controller/kubefed/kubefed_controller.go
@@ -277,6 +277,11 @@ func (r *ReconcileKubeFed) install(instance *kubefedv1alpha1.KubeFed) error {
 		return err
 	}
 	log.Info("Install succeeded", "version", version.Version)
+	resources, err := mf.Parse(*filename, *recursive)
+	if err == nil {
+		log.Info("Parsed the resources again for the next reconcile from: ", "path", *filename)
+		r.config.Resources = resources
+	}
 	return nil
 }
 


### PR DESCRIPTION
This commit fixes the issue where if a user reconciles a KubeFed
instance that is namespace scoped, deletes it, and reconciles
a cluster scoped instance, the cluster scoped resources will not be
applied. For instance clusterrole, clusterrolebinding would have been
skipped prior to this change.