### PR TITLE
Rename the OCP package name to openshift-kubefed-operator

### DIFF
--- a/deploy/olm-catalog/kubefed-operator/kubefed-operator.package.yaml
+++ b/deploy/olm-catalog/kubefed-operator/kubefed-operator.package.yaml
@@ -1,4 +1,4 @@
-packageName: kubefed-operator
+packageName: openshift-kubefed-operator
 channels:
 - name: alpha
   currentCSV: kubefed-operator.v4.2.0


### PR DESCRIPTION
Rename the package name of the operator to openshift-kubefed-operator for OCP.